### PR TITLE
feat(mcp-server): expose klog options

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -266,6 +266,8 @@ func run(ctx context.Context) error {
 	// cobra has to know that we pass pass flags with flag lib, otherwise it creates conflict with flags.parse() method
 	// We add just the klog flags we want, not all the klog flags (there are a lot, most of them are very niche)
 	rootCmd.PersistentFlags().AddGoFlag(klogFlags.Lookup("v"))
+	rootCmd.PersistentFlags().AddGoFlag(klogFlags.Lookup("logtostderr"))
+	rootCmd.PersistentFlags().AddGoFlag(klogFlags.Lookup("log_file"))
 
 	// do this early, before the third-party code logs anything.
 	redirectStdLogToKlog()


### PR DESCRIPTION
Expose `--logtostderr` and `--log_file` klog options.

Example:
```sh
# Show klog message on SSE protocol.
kubectl-ai --mcp-server \
    --mcp-sse-host=127.0.0.1 \
    --mcp-sse-port=8888 \
    --mcp-transport=sse \
    -v=9 \
    --log_file='' \
    --logtostderr=true
```